### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   Pre_Merge:
+    permissions:
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/next-release-tag/security/code-scanning/4](https://github.com/slord399/next-release-tag/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow or to the job. The minimal starting point is `contents: read`, but some steps (such as `LouisBrunner/checks-action` and possibly `actions/github-script` for status checks) may require additional permissions, such as `checks: write`. The best way to fix this is to add a `permissions` block at the job level for `Pre_Merge`, specifying the least privileges required. For this workflow, the recommended permissions are:

- `contents: read` (for checking out code)
- `checks: write` (for creating status checks)
- Optionally, if the workflow needs to interact with issues or pull requests, add those as needed.

The change should be made in `.github/workflows/pre-merge.yml`, by adding a `permissions` block under the `Pre_Merge` job, above `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
