### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -1,4 +1,6 @@
 name: Verify build
+permissions:
+  contents: read
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/next-release-tag/security/code-scanning/3](https://github.com/slord399/next-release-tag/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code, installs dependencies, builds, and uploads artifacts, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read repository contents (needed for `actions/checkout`). This block should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
