### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   Test:
+    permissions:
+      contents: read
     name: OS ${{ matrix.os }} + node ${{ matrix.node }}
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/next-release-tag/security/code-scanning/2](https://github.com/slord399/next-release-tag/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow or to the specific job. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. This should be added at the job level (under `jobs.Test`) or at the workflow root (above `jobs:`) if all jobs require the same permissions. Since the error is flagged at the job level, and the workflow only has one job, either location is acceptable. For clarity and future extensibility, adding it at the job level is preferred. No additional imports or definitions are needed; just add the `permissions` block under the job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
