### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-pnpm-test.yml
+++ b/.github/workflows/update-pnpm-test.yml
@@ -1,5 +1,8 @@
 name: Update-pnpm
 
+permissions:
+  contents: read
+
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/slord399/next-release-tag/security/code-scanning/5](https://github.com/slord399/next-release-tag/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN. Since the workflow only checks out code and installs/updates dependencies locally (with no write operations to the repository or other resources), the minimal required permission is `contents: read`. This block should be added at the root level of the workflow file (above or below the `on:` block), so it applies to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
