### PR TITLE
Build(deps-dev): bump @octokit/request from 10.0.8 to 10.0.9

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37339,178 +37339,175 @@ ${pendingInterceptorsFormatter.format(pending)}
       /***/
     },
 
-    /***/ 1120: /***/ (module) => {
+    /***/ 4649: /***/ (__unused_webpack_module, exports) => {
       'use strict';
       var __webpack_unused_export__;
 
-      const NullObject = function NullObject() {};
-      NullObject.prototype = Object.create(null);
-
-      /**
-       * RegExp to match *( ";" parameter ) in RFC 7231 sec 3.1.1.1
-       *
-       * parameter     = token "=" ( token / quoted-string )
-       * token         = 1*tchar
-       * tchar         = "!" / "#" / "$" / "%" / "&" / "'" / "*"
-       *               / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
-       *               / DIGIT / ALPHA
-       *               ; any VCHAR, except delimiters
-       * quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE
-       * qdtext        = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
-       * obs-text      = %x80-FF
-       * quoted-pair   = "\" ( HTAB / SP / VCHAR / obs-text )
+      /*!
+       * content-type
+       * Copyright(c) 2015 Douglas Christopher Wilson
+       * MIT Licensed
        */
-      const paramRE =
-        /; *([!#$%&'*+.^\w`|~-]+)=("(?:[\v\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\v\u0020-\u00ff])*"|[!#$%&'*+.^\w`|~-]+) */gu;
-
+      __webpack_unused_export__ = { value: true };
+      __webpack_unused_export__ = format;
+      exports.qg = parse;
+      const TEXT_REGEXP = /^[\u0009\u0020-\u007e\u0080-\u00ff]*$/;
+      const TOKEN_REGEXP = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
       /**
-       * RegExp to match quoted-pair in RFC 7230 sec 3.2.6
-       *
-       * quoted-pair = "\" ( HTAB / SP / VCHAR / obs-text )
-       * obs-text    = %x80-FF
+       * RegExp to match chars that must be quoted-pair in RFC 9110 sec 5.6.4
        */
-      const quotedPairRE = /\\([\v\u0020-\u00ff])/gu;
-
+      const QUOTE_REGEXP = /[\\"]/g;
       /**
-       * RegExp to match type in RFC 7231 sec 3.1.1.1
+       * RegExp to match type in RFC 9110 sec 8.3.1
        *
        * media-type = type "/" subtype
        * type       = token
        * subtype    = token
        */
-      const mediaTypeRE = /^[!#$%&'*+.^\w|~-]+\/[!#$%&'*+.^\w|~-]+$/u;
-
-      // default ContentType to prevent repeated object creation
-      const defaultContentType = { type: '', parameters: new NullObject() };
-      Object.freeze(defaultContentType.parameters);
-      Object.freeze(defaultContentType);
-
+      const TYPE_REGEXP =
+        /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
       /**
-       * Parse media type to object.
-       *
-       * @param {string|object} header
-       * @return {Object}
-       * @public
+       * Null object perf optimization. Faster than `Object.create(null)` and `{ __proto__: null }`.
        */
-
-      function parse(header) {
-        if (typeof header !== 'string') {
-          throw new TypeError(
-            'argument header is required and must be a string'
-          );
+      const NullObject = /* @__PURE__ */ (() => {
+        const C = function () {};
+        C.prototype = Object.create(null);
+        return C;
+      })();
+      /**
+       * Format an object into a `Content-Type` header.
+       */
+      function format(obj) {
+        const { type, parameters } = obj;
+        if (!type || !TYPE_REGEXP.test(type)) {
+          throw new TypeError(`Invalid type: ${type}`);
         }
-
-        let index = header.indexOf(';');
-        const type =
-          index !== -1 ? header.slice(0, index).trim() : header.trim();
-
-        if (mediaTypeRE.test(type) === false) {
-          throw new TypeError('invalid media type');
-        }
-
-        const result = {
-          type: type.toLowerCase(),
-          parameters: new NullObject(),
-        };
-
-        // parse parameters
-        if (index === -1) {
-          return result;
-        }
-
-        let key;
-        let match;
-        let value;
-
-        paramRE.lastIndex = index;
-
-        while ((match = paramRE.exec(header))) {
-          if (match.index !== index) {
-            throw new TypeError('invalid parameter format');
+        let result = type;
+        if (parameters) {
+          for (const param of Object.keys(parameters)) {
+            if (!TOKEN_REGEXP.test(param)) {
+              throw new TypeError(`Invalid parameter name: ${param}`);
+            }
+            result += `; ${param}=${qstring(parameters[param])}`;
           }
-
-          index += match[0].length;
-          key = match[1].toLowerCase();
-          value = match[2];
-
-          if (value[0] === '"') {
-            // remove quotes and escapes
-            value = value.slice(1, value.length - 1);
-
-            quotedPairRE.test(value) &&
-              (value = value.replace(quotedPairRE, '$1'));
-          }
-
-          result.parameters[key] = value;
         }
-
-        if (index !== header.length) {
-          throw new TypeError('invalid parameter format');
-        }
-
         return result;
       }
-
-      function safeParse(header) {
-        if (typeof header !== 'string') {
-          return defaultContentType;
-        }
-
-        let index = header.indexOf(';');
-        const type =
-          index !== -1 ? header.slice(0, index).trim() : header.trim();
-
-        if (mediaTypeRE.test(type) === false) {
-          return defaultContentType;
-        }
-
-        const result = {
-          type: type.toLowerCase(),
-          parameters: new NullObject(),
-        };
-
-        // parse parameters
-        if (index === -1) {
-          return result;
-        }
-
-        let key;
-        let match;
-        let value;
-
-        paramRE.lastIndex = index;
-
-        while ((match = paramRE.exec(header))) {
-          if (match.index !== index) {
-            return defaultContentType;
-          }
-
-          index += match[0].length;
-          key = match[1].toLowerCase();
-          value = match[2];
-
-          if (value[0] === '"') {
-            // remove quotes and escapes
-            value = value.slice(1, value.length - 1);
-
-            quotedPairRE.test(value) &&
-              (value = value.replace(quotedPairRE, '$1'));
-          }
-
-          result.parameters[key] = value;
-        }
-
-        if (index !== header.length) {
-          return defaultContentType;
-        }
-
-        return result;
+      /**
+       * Parse a `Content-Type` header.
+       */
+      function parse(header, options) {
+        const len = header.length;
+        let index = skipOWS(header, 0, len);
+        const valueStart = index;
+        index = skipValue(header, index, len);
+        const valueEnd = trailingOWS(header, valueStart, index);
+        const type = header.slice(valueStart, valueEnd).toLowerCase();
+        const parameters =
+          options?.parameters === false
+            ? new NullObject()
+            : parseParameters(header, index, len);
+        return { type, parameters };
       }
-
-      __webpack_unused_export__ = { parse, safeParse };
-      __webpack_unused_export__ = parse;
-      module.exports.xL = safeParse;
-      __webpack_unused_export__ = defaultContentType;
+      const SP = 32; // " "
+      const HTAB = 9; // "\t"
+      const SEMI = 59; // ";"
+      const EQ = 61; // "="
+      const DQUOTE = 34; // '"'
+      const BSLASH = 92; // "\\"
+      /**
+       * Parses the parameters of a `Content-Type` header starting at the given index.
+       */
+      function parseParameters(header, index, len) {
+        const parameters = new NullObject();
+        parameter: while (index < len) {
+          index = skipOWS(header, index + 1 /* Skip over ; */, len);
+          const keyStart = index;
+          while (index < len) {
+            const code = header.charCodeAt(index);
+            if (code === SEMI) continue parameter;
+            if (code === EQ) {
+              const keyEnd = trailingOWS(header, keyStart, index);
+              const key = header.slice(keyStart, keyEnd).toLowerCase();
+              index = skipOWS(header, index + 1, len);
+              if (index < len && header.charCodeAt(index) === DQUOTE) {
+                index++;
+                let value = '';
+                while (index < len) {
+                  const code = header.charCodeAt(index++);
+                  if (code === DQUOTE) {
+                    index = skipValue(header, index, len);
+                    if (parameters[key] === undefined) parameters[key] = value;
+                    break;
+                  }
+                  if (code === BSLASH && index < len) {
+                    value += header[index++];
+                    continue;
+                  }
+                  value += String.fromCharCode(code);
+                }
+                continue parameter;
+              }
+              const valueStart = index;
+              index = skipValue(header, index, len);
+              if (parameters[key] === undefined) {
+                const valueEnd = trailingOWS(header, valueStart, index);
+                parameters[key] = header.slice(valueStart, valueEnd);
+              }
+              continue parameter;
+            }
+            index++;
+          }
+        }
+        return parameters;
+      }
+      /**
+       * Skip over characters until a semicolon.
+       */
+      function skipValue(str, index, len) {
+        while (index < len) {
+          const char = str.charCodeAt(index);
+          if (char === SEMI) break;
+          index++;
+        }
+        return index;
+      }
+      /**
+       * Skip optional whitespace (OWS) in an HTTP header value.
+       *
+       * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
+       */
+      function skipOWS(header, index, len) {
+        while (index < len) {
+          const char = header.charCodeAt(index);
+          if (char !== SP && char !== HTAB) break;
+          index++;
+        }
+        return index;
+      }
+      /**
+       * Trim optional whitespace (OWS) from the end of a substring.
+       *
+       * OWS is defined in RFC 9110 sec 5.6.3 as SP (" ") or HTAB ("\t").
+       */
+      function trailingOWS(header, start, end) {
+        while (end > start) {
+          const char = header.charCodeAt(end - 1);
+          if (char !== SP && char !== HTAB) break;
+          end--;
+        }
+        return end;
+      }
+      /**
+       * Serialize a parameter value.
+       */
+      function qstring(str) {
+        if (TOKEN_REGEXP.test(str)) return str;
+        if (TEXT_REGEXP.test(str))
+          return `"${str.replace(QUOTE_REGEXP, '\\$&')}"`;
+        throw new TypeError(`Invalid parameter value: ${str}`);
+      }
+      //# sourceMappingURL=index.js.map
 
       /***/
     },
@@ -41819,8 +41816,8 @@ ${pendingInterceptorsFormatter.format(pending)}
     // pkg/dist-src/index.js
     var endpoint = withDefaults(null, DEFAULTS);
 
-    // EXTERNAL MODULE: ./node_modules/fast-content-type-parse/index.js
-    var fast_content_type_parse = __nccwpck_require__(1120); // CONCATENATED MODULE: ./node_modules/json-with-bigint/json-with-bigint.js
+    // EXTERNAL MODULE: ./node_modules/content-type/dist/index.js
+    var dist = __nccwpck_require__(4649); // CONCATENATED MODULE: ./node_modules/json-with-bigint/json-with-bigint.js
     const noiseValue = /^-?\d+n+$/; // Noise - strings that match the custom format before being converted to it
     const originalStringify = JSON.stringify;
     const originalParse = JSON.parse;
@@ -42008,7 +42005,7 @@ ${pendingInterceptorsFormatter.format(pending)}
     // pkg/dist-src/defaults.js
 
     // pkg/dist-src/version.js
-    var dist_bundle_VERSION = '10.0.8';
+    var dist_bundle_VERSION = '10.0.9';
 
     // pkg/dist-src/defaults.js
     var defaults_default = {
@@ -42151,9 +42148,7 @@ ${pendingInterceptorsFormatter.format(pending)}
       if (!contentType) {
         return response.text().catch(noop);
       }
-      const mimetype = (0, fast_content_type_parse /* safeParse */.xL)(
-        contentType
-      );
+      const mimetype = (0, dist /* parse */.qg)(contentType);
       if (isJSONResponse(mimetype)) {
         let text = '';
         try {

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -448,32 +448,31 @@ Apache-2.0
    limitations under the License.
 
 
-fast-content-type-parse
+content-type
 MIT
-MIT License
+(The MIT License)
 
-Copyright (c) 2023 The Fastify Team
+Copyright (c) 2015 Douglas Christopher Wilson
 
-The Fastify team members are listed at https://github.com/fastify/fastify#team
-and in the README file.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 json-with-bigint
 MIT

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@stylistic/eslint-plugin": "^2.6.1",
         "@kesills/eslint-config-airbnb-typescript": "20.0.0",
         "@octokit/plugin-paginate-rest": "14.0.0",
-        "@octokit/request": "10.0.8",
+        "@octokit/request": "10.0.9",
         "@octokit/request-error": "7.1.0",
         "@types/node": "^25.7.0",
         "@typescript-eslint/eslint-plugin": "8",
@@ -47,7 +47,7 @@
         "vitest": "^4.1.6"
     },
     "resolutions": {
-        "@octokit/request": "10.0.8",
+        "@octokit/request": "10.0.9",
         "esbuild": "0.28.0",
         "js-yaml": "4.1.1",
         "glob": "11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,14 +372,15 @@
   dependencies:
     "@octokit/types" "^16.0.0"
 
-"@octokit/request@10.0.8", "@octokit/request@^10.0.6", "@octokit/request@^10.0.7":
-  version "10.0.8"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-10.0.8.tgz#6609a5a38ad6f8ee203d9eb8ac9361d906a4414e"
-  integrity sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==
+"@octokit/request@10.0.9", "@octokit/request@^10.0.6", "@octokit/request@^10.0.7":
+  version "10.0.9"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-10.0.9.tgz#6e75648ace44e7416d06ff96c345f9f9de23df02"
+  integrity sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==
   dependencies:
     "@octokit/endpoint" "^11.0.3"
     "@octokit/request-error" "^7.0.2"
     "@octokit/types" "^16.0.0"
+    content-type "^2.0.0"
     fast-content-type-parse "^3.0.0"
     json-with-bigint "^3.5.3"
     universal-user-agent "^7.0.2"
@@ -1083,6 +1084,11 @@ confusing-browser-globals@^1.0.10:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
+
+content-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-2.0.0.tgz#2fb3ede69dffa0af78ca7c4ce7589680638b56df"
+  integrity sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==
 
 convert-source-map@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I have updated `@octokit/request` from version `10.0.8` to `10.0.9` as requested in the pull request.

Key changes:
- Updated `@octokit/request` version in `package.json`'s `devDependencies` and `resolutions`.
- Updated `yarn.lock` by running `yarn install`.
- Regenerated `dist/index.js` and `dist/licenses.txt` using `yarn dist` to ensure the bundled artifacts are in sync with the new dependency version.
- Verified that the new dependency is correctly bundled and that all tests pass.

---
*PR created automatically by Jules for task [3462442099383678696](https://jules.google.com/task/3462442099383678696) started by @slord399*