### PR TITLE
Fix JS-YAML quadratic-complexity DoS vulnerability (CVE-2026-53550)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "resolutions": {
         "@octokit/request": "10.0.11",
         "esbuild": "0.28.1",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "glob": "11.1.0",
         "undici": "6.24.1",
         "picomatch": "4.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,10 +2134,10 @@ jackspeak@^4.1.1:
   dependencies:
     "@isaacs/cliui" "^9.0.0"
 
-js-yaml@4.1.1, js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@4.2.0, js-yaml@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Upgraded `js-yaml` from version `4.1.1` to `4.2.0` in package resolutions to mitigate the quadratic-complexity DoS vulnerability in merge key handling via repeated aliases (CVE-2026-53550). Run yarn dist to verify all tests pass and regenerate build artifacts. No core functionality is impacted.

---
*PR created automatically by Jules for task [4209823734510820734](https://jules.google.com/task/4209823734510820734) started by @slord399*