### PR TITLE
Fix js-yaml and brace-expansion vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,14 @@
     "resolutions": {
         "@octokit/request": "10.0.11",
         "esbuild": "0.28.1",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "glob": "11.1.0",
         "undici": "6.24.1",
-        "picomatch": "4.0.4"
+        "picomatch": "4.0.4",
+        "eslint/minimatch/brace-expansion": "1.1.16",
+        "eslint-plugin-import/minimatch/brace-expansion": "1.1.16",
+        "eslint-config-airbnb-base/eslint-plugin-import/minimatch/brace-expansion": "1.1.16",
+        "@eslint/eslintrc/minimatch/brace-expansion": "1.1.16",
+        "@humanwhocodes/config-array/minimatch/brace-expansion": "1.1.16"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,10 +1012,10 @@ before-after-hook@^4.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-4.0.0.tgz#cf1447ab9160df6a40f3621da64d6ffc36050cb9"
   integrity sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==
 
-brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+brace-expansion@1.1.16, brace-expansion@^1.1.7:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -2074,10 +2074,10 @@ jackspeak@^4.1.1:
   dependencies:
     "@isaacs/cliui" "^9.0.0"
 
-js-yaml@4.2.0, js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@4.3.0, js-yaml@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
This change fixes the Dependabot alerts for `js-yaml` and `brace-expansion` in `yarn.lock` and ensures the CI pipeline passes.
- `js-yaml`: Updated global resolution from 4.2.0 to 4.3.0.
- `brace-expansion`: Pinning brace-expansion v1.x to 1.1.16 selectively using path-scoped resolutions for ESLint and its plugins to avoid breaking newer major version dependencies (v5.x) required by other devDependencies.

---
*PR created automatically by Jules for task [14536962098906950147](https://jules.google.com/task/14536962098906950147) started by @slord399*