### PR TITLE
Upgrade direct and indirect dependencies to fix security vulnerabilities

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10528,7 +10528,13 @@
             } else if (typeof val[i] === 'object') {
               throw new InvalidArgumentError(`invalid ${key} header`);
             } else {
-              arr.push(`${val[i]}`);
+              // Coerce primitives (and reject unsafe coercions such as functions
+              // with a crafted toString/Symbol.toPrimitive).
+              const str = `${val[i]}`;
+              if (!isValidHeaderValue(str)) {
+                throw new InvalidArgumentError(`invalid ${key} header`);
+              }
+              arr.push(str);
             }
           }
           val = arr;
@@ -10539,7 +10545,12 @@
         } else if (val === null) {
           val = '';
         } else {
+          // Coerce primitives (and reject unsafe coercions such as functions
+          // with a crafted toString/Symbol.toPrimitive).
           val = `${val}`;
+          if (!isValidHeaderValue(val)) {
+            throw new InvalidArgumentError(`invalid ${key} header`);
+          }
         }
 
         if (headerName === 'host') {
@@ -11647,8 +11658,6 @@
           connect,
           ...options
         } = {}) {
-          super();
-
           if (typeof factory !== 'function') {
             throw new InvalidArgumentError('factory must be a function.');
           }
@@ -11668,6 +11677,8 @@
               'maxRedirections must be a positive number'
             );
           }
+
+          super(options);
 
           if (connect && typeof connect !== 'function') {
             connect = { ...connect };
@@ -12032,6 +12043,7 @@
         RequestContentLengthMismatchError,
         ResponseContentLengthMismatchError,
         RequestAbortedError,
+        InvalidArgumentError,
         HeadersTimeoutError,
         HeadersOverflowError,
         SocketError,
@@ -12079,6 +12091,11 @@
       const FastBuffer = Buffer[Symbol.species];
       const addListener = util.addListener;
       const removeAllListeners = util.removeAllListeners;
+      const kIdleSocketValidation = Symbol('kIdleSocketValidation');
+      const kIdleSocketValidationTimeout = Symbol(
+        'kIdleSocketValidationTimeout'
+      );
+      const kSocketUsed = Symbol('kSocketUsed');
 
       let extractBody;
 
@@ -12352,33 +12369,72 @@
             const offset =
               llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr;
 
-            if (ret === constants.ERROR.PAUSED_UPGRADE) {
-              this.onUpgrade(data.slice(offset));
-            } else if (ret === constants.ERROR.PAUSED) {
-              this.paused = true;
-              socket.unshift(data.slice(offset));
-            } else if (ret !== constants.ERROR.OK) {
-              const ptr = llhttp.llhttp_get_error_reason(this.ptr);
-              let message = '';
-              /* istanbul ignore else: difficult to make a test case for */
-              if (ptr) {
-                const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(
-                  0
-                );
-                message =
-                  'Response does not match the HTTP/1.1 protocol (' +
-                  Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-                  ')';
+            if (ret !== constants.ERROR.OK) {
+              const body = data.subarray(offset);
+
+              if (ret === constants.ERROR.PAUSED_UPGRADE) {
+                this.onUpgrade(body);
+              } else if (ret === constants.ERROR.PAUSED) {
+                this.paused = true;
+                socket.unshift(body);
+              } else {
+                throw this.createError(ret, body);
               }
-              throw new HTTPParserError(
-                message,
-                constants.ERROR[ret],
-                data.slice(offset)
-              );
             }
           } catch (err) {
             util.destroy(socket, err);
           }
+        }
+
+        finish() {
+          assert(currentParser === null);
+          assert(this.ptr != null);
+          assert(!this.paused);
+
+          const { llhttp } = this;
+
+          let ret;
+
+          try {
+            currentParser = this;
+            ret = llhttp.llhttp_finish(this.ptr);
+          } finally {
+            currentParser = null;
+          }
+
+          if (ret === constants.ERROR.OK) {
+            return null;
+          }
+
+          if (
+            ret === constants.ERROR.PAUSED ||
+            ret === constants.ERROR.PAUSED_UPGRADE
+          ) {
+            this.paused = true;
+            return null;
+          }
+
+          return this.createError(ret, EMPTY_BUF);
+        }
+
+        createError(ret, data) {
+          const { llhttp, contentLength, bytesRead } = this;
+
+          if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+            return new ResponseContentLengthMismatchError();
+          }
+
+          const ptr = llhttp.llhttp_get_error_reason(this.ptr);
+          let message = '';
+          if (ptr) {
+            const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
+            message =
+              'Response does not match the HTTP/1.1 protocol (' +
+              Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+              ')';
+          }
+
+          return new HTTPParserError(message, constants.ERROR[ret], data);
         }
 
         destroy() {
@@ -12405,6 +12461,14 @@
 
           /* istanbul ignore next: difficult to make a test case for */
           if (socket.destroyed) {
+            return -1;
+          }
+
+          if (client[kRunning] === 0) {
+            util.destroy(
+              socket,
+              new SocketError('bad response', util.getSocketInfo(socket))
+            );
             return -1;
           }
 
@@ -12516,6 +12580,14 @@
 
           /* istanbul ignore next: difficult to make a test case for */
           if (socket.destroyed) {
+            return -1;
+          }
+
+          if (client[kRunning] === 0) {
+            util.destroy(
+              socket,
+              new SocketError('bad response', util.getSocketInfo(socket))
+            );
             return -1;
           }
 
@@ -12720,6 +12792,7 @@
           request.onComplete(headers);
 
           client[kQueue][client[kRunningIdx]++] = null;
+          socket[kSocketUsed] = true;
 
           if (socket[kWriting]) {
             assert(client[kRunning] === 0);
@@ -12782,6 +12855,9 @@
         socket[kWriting] = false;
         socket[kReset] = false;
         socket[kBlocking] = false;
+        socket[kIdleSocketValidation] = 0;
+        socket[kIdleSocketValidationTimeout] = null;
+        socket[kSocketUsed] = false;
         socket[kParser] = new Parser(client, socket, llhttpInstance);
 
         addListener(socket, 'error', function (err) {
@@ -12796,8 +12872,11 @@
             parser.statusCode &&
             !parser.shouldKeepAlive
           ) {
-            // We treat all incoming data so for as a valid response.
-            parser.onMessageComplete();
+            const parserErr = parser.finish();
+            if (parserErr) {
+              this[kError] = parserErr;
+              this[kClient][kOnError](parserErr);
+            }
             return;
           }
 
@@ -12816,8 +12895,10 @@
           const parser = this[kParser];
 
           if (parser.statusCode && !parser.shouldKeepAlive) {
-            // We treat all incoming data so far as a valid response.
-            parser.onMessageComplete();
+            const parserErr = parser.finish();
+            if (parserErr) {
+              util.destroy(this, parserErr);
+            }
             return;
           }
 
@@ -12830,10 +12911,11 @@
           const client = this[kClient];
           const parser = this[kParser];
 
+          clearIdleSocketValidation(this);
+
           if (parser) {
             if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-              // We treat all incoming data so far as a valid response.
-              parser.onMessageComplete();
+              this[kError] = parser.finish() || this[kError];
             }
 
             this[kParser].destroy();
@@ -12897,7 +12979,12 @@
             return socket.destroyed;
           },
           busy(request) {
-            if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+            if (
+              socket[kWriting] ||
+              socket[kReset] ||
+              socket[kBlocking] ||
+              socket[kIdleSocketValidation] === 1
+            ) {
               return true;
             }
 
@@ -12943,6 +13030,31 @@
         };
       }
 
+      function clearIdleSocketValidation(socket) {
+        if (socket[kIdleSocketValidationTimeout]) {
+          clearTimeout(socket[kIdleSocketValidationTimeout]);
+          socket[kIdleSocketValidationTimeout] = null;
+        }
+
+        socket[kIdleSocketValidation] = 0;
+      }
+
+      function scheduleIdleSocketValidation(client, socket) {
+        socket[kIdleSocketValidation] = 1;
+        socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+          socket[kIdleSocketValidationTimeout] = null;
+          socket[kIdleSocketValidation] = 2;
+
+          if (client[kSocket] === socket && !socket.destroyed) {
+            client[kResume]();
+          }
+        }, 0);
+        socket[kIdleSocketValidationTimeout].unref?.();
+      }
+
+      /**
+       * @param {import('./client.js')} client
+       */
       function resumeH1(client) {
         const socket = client[kSocket];
 
@@ -12955,6 +13067,36 @@
           } else if (socket[kNoRef] && socket.ref) {
             socket.ref();
             socket[kNoRef] = false;
+          }
+
+          if (
+            client[kRunning] === 0 &&
+            client[kPending] > 0 &&
+            socket[kSocketUsed]
+          ) {
+            if (socket[kIdleSocketValidation] === 0) {
+              scheduleIdleSocketValidation(client, socket);
+              socket[kParser].readMore();
+              if (socket.destroyed) {
+                return;
+              }
+              return;
+            }
+
+            if (socket[kIdleSocketValidation] === 1) {
+              socket[kParser].readMore();
+              if (socket.destroyed) {
+                return;
+              }
+              return;
+            }
+          }
+
+          if (client[kRunning] === 0) {
+            socket[kParser].readMore();
+            if (socket.destroyed) {
+              return;
+            }
           }
 
           if (client[kSize] === 0) {
@@ -13021,12 +13163,20 @@
           }
           body = bodyStream.stream;
           contentLength = bodyStream.length;
-        } else if (
-          util.isBlobLike(body) &&
-          request.contentType == null &&
-          body.type
-        ) {
-          headers.push('content-type', body.type);
+        } else if (util.isBlobLike(body) && request.contentType == null) {
+          const contentType = body.type;
+          if (contentType) {
+            const contentTypeValue = `${contentType}`;
+            if (!util.isValidHeaderValue(contentTypeValue)) {
+              util.errorRequest(
+                client,
+                request,
+                new InvalidArgumentError('invalid content-type header')
+              );
+              return false;
+            }
+            headers.push('content-type', contentTypeValue);
+          }
         }
 
         if (body && typeof body.read === 'function') {
@@ -13072,6 +13222,7 @@
         }
 
         const socket = client[kSocket];
+        clearIdleSocketValidation(socket);
 
         const abort = (err) => {
           if (request.aborted || request.completed) {
@@ -14658,9 +14809,10 @@
             // h2
             maxConcurrentStreams,
             allowH2,
+            webSocket,
           } = {}
         ) {
-          super();
+          super({ webSocket });
 
           if (keepAlive !== undefined) {
             throw new InvalidArgumentError(
@@ -15303,15 +15455,25 @@
       const kOnDestroyed = Symbol('onDestroyed');
       const kOnClosed = Symbol('onClosed');
       const kInterceptedDispatch = Symbol('Intercepted Dispatch');
+      const kWebSocketOptions = Symbol('webSocketOptions');
 
       class DispatcherBase extends Dispatcher {
-        constructor() {
+        constructor(opts) {
           super();
 
           this[kDestroyed] = false;
           this[kOnDestroyed] = null;
           this[kClosed] = false;
           this[kOnClosed] = [];
+          this[kWebSocketOptions] = opts?.webSocket ?? {};
+        }
+
+        get webSocketOptions() {
+          return {
+            maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
+            maxPayloadSize:
+              this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024,
+          };
         }
 
         get destroyed() {
@@ -15916,8 +16078,8 @@
       const kStats = Symbol('stats');
 
       class PoolBase extends DispatcherBase {
-        constructor() {
-          super();
+        constructor(opts) {
+          super(opts);
 
           this[kQueue] = new FixedQueue();
           this[kClients] = [];
@@ -16180,8 +16342,6 @@
             ...options
           } = {}
         ) {
-          super();
-
           if (
             connections != null &&
             (!Number.isFinite(connections) || connections < 0)
@@ -16216,6 +16376,8 @@
               ...connect,
             });
           }
+
+          super(options);
 
           this[kInterceptors] =
             options.interceptors?.Pool &&
@@ -17022,6 +17184,33 @@
         return new Date(retryAfter).getTime() - current;
       }
 
+      function validatePartialResponseContentLength(
+        headers,
+        range,
+        statusCode,
+        retryCount
+      ) {
+        const contentLength = headers['content-length'];
+        if (contentLength == null) {
+          return null;
+        }
+
+        if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+          return null;
+        }
+
+        const length = Number(contentLength);
+        const expectedLength = range.end - range.start + 1;
+        if (!Number.isFinite(length) || length !== expectedLength) {
+          return new RequestRetryError('Content-Length mismatch', statusCode, {
+            headers,
+            data: { count: retryCount },
+          });
+        }
+
+        return null;
+      }
+
       class RetryHandler {
         constructor(opts, handlers) {
           const { retryOptions, ...dispatchOpts } = opts;
@@ -17254,6 +17443,17 @@
               return false;
             }
 
+            const contentLengthError = validatePartialResponseContentLength(
+              headers,
+              contentRange,
+              statusCode,
+              this.retryCount
+            );
+            if (contentLengthError != null) {
+              this.abort(contentLengthError);
+              return false;
+            }
+
             const { start, size, end = size - 1 } = contentRange;
 
             assert(this.start === start, 'content-range mismatch');
@@ -17278,6 +17478,17 @@
                   resume,
                   statusMessage
                 );
+              }
+
+              const contentLengthError = validatePartialResponseContentLength(
+                headers,
+                range,
+                statusCode,
+                this.retryCount
+              );
+              if (contentLengthError != null) {
+                this.abort(contentLengthError);
+                return false;
               }
 
               const { start, size, end = size - 1 } = range;
@@ -21823,32 +22034,25 @@ ${pendingInterceptorsFormatter.format(pending)}
           // If the attribute-name case-insensitively matches the string
           // "SameSite", the user agent MUST process the cookie-av as follows:
 
-          // 1. Let enforcement be "Default".
-          let enforcement = 'Default';
-
           const attributeValueLowercase = attributeValue.toLowerCase();
-          // 2. If cookie-av's attribute-value is a case-insensitive match for
-          //    "None", set enforcement to "None".
-          if (attributeValueLowercase.includes('none')) {
-            enforcement = 'None';
-          }
 
-          // 3. If cookie-av's attribute-value is a case-insensitive match for
-          //    "Strict", set enforcement to "Strict".
-          if (attributeValueLowercase.includes('strict')) {
-            enforcement = 'Strict';
+          // 1. If cookie-av's attribute-value is a case-insensitive match for
+          //    "None", append an attribute to the cookie-attribute-list with an
+          //    attribute-name of "SameSite" and an attribute-value of "None".
+          if (attributeValueLowercase === 'none') {
+            cookieAttributeList.sameSite = 'None';
+          } else if (attributeValueLowercase === 'strict') {
+            // 2. If cookie-av's attribute-value is a case-insensitive match for
+            //    "Strict", append an attribute to the cookie-attribute-list with
+            //    an attribute-name of "SameSite" and an attribute-value of
+            //    "Strict".
+            cookieAttributeList.sameSite = 'Strict';
+          } else if (attributeValueLowercase === 'lax') {
+            // 3. If cookie-av's attribute-value is a case-insensitive match for
+            //    "Lax", append an attribute to the cookie-attribute-list with an
+            //    attribute-name of "SameSite" and an attribute-value of "Lax".
+            cookieAttributeList.sameSite = 'Lax';
           }
-
-          // 4. If cookie-av's attribute-value is a case-insensitive match for
-          //    "Lax", set enforcement to "Lax".
-          if (attributeValueLowercase.includes('lax')) {
-            enforcement = 'Lax';
-          }
-
-          // 5. Append an attribute to the cookie-attribute-list with an
-          //    attribute-name of "SameSite" and an attribute-value of
-          //    enforcement.
-          cookieAttributeList.sameSite = enforcement;
         } else {
           cookieAttributeList.unparsed ??= [];
 
@@ -21977,7 +22181,7 @@ ${pendingInterceptorsFormatter.format(pending)}
 
           if (
             code < 0x20 || // exclude CTLs (0-31)
-            code === 0x7f || // DEL
+            code > 0x7e || // exclude DEL and non-ascii
             code === 0x3b // ;
           ) {
             throw new Error('Invalid cookie path');
@@ -21986,16 +22190,86 @@ ${pendingInterceptorsFormatter.format(pending)}
       }
 
       /**
-       * I have no idea why these values aren't allowed to be honest,
-       * but Deno tests these. - Khafra
+       * <let-dig> ::= <letter> | <digit>
+       *
+       * <letter> ::= any one of the 52 alphabetic characters A through Z in
+       * upper case and a through z in lower case
+       *
+       * <digit> ::= any one of the ten digits 0 through 9r
+       *
+       * @see https://www.rfc-editor.org/rfc/rfc1034#section-3.5
+       * @param {number} code
+       */
+      function isLetterOrDigit(code) {
+        return (
+          (code >= 0x30 && code <= 0x39) || // 0-9
+          (code >= 0x41 && code <= 0x5a) || // A-Z
+          (code >= 0x61 && code <= 0x7a) // a-z
+        );
+      }
+
+      /**
+       * Validates a cookie domain against the "preferred name syntax".
+       *
+       * <domain>      ::= <subdomain> | " "
+       * <subdomain>   ::= <label> | <subdomain> "." <label>
+       * <label>       ::= <let-dig> [ [ <ldh-str> ] <let-dig> ]
+       * <ldh-str>     ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+       * <let-dig-hyp> ::= <let-dig> | "-"
+       *
+       * @see https://www.rfc-editor.org/rfc/rfc1034#section-3.5
+       * @see https://www.rfc-editor.org/rfc/rfc1123#section-2.1
+       * @see https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4
        * @param {string} domain
        */
       function validateCookieDomain(domain) {
+        // <domain> ::= <subdomain> | " "
+        if (domain === ' ') {
+          return;
+        }
+
+        if (domain.length > 255) {
+          throw new Error('Invalid cookie domain');
+        }
+
+        let labelLength = 0;
+
+        for (let i = 0; i < domain.length; ++i) {
+          const code = domain.charCodeAt(i);
+
+          if (code === 0x2e) {
+            if (labelLength === 0) {
+              throw new Error('Invalid cookie domain');
+            }
+
+            if (domain.charCodeAt(i - 1) === 0x2d) {
+              // "-"
+              throw new Error('Invalid cookie domain');
+            }
+
+            labelLength = 0;
+            continue;
+          }
+
+          if (labelLength === 0 && !isLetterOrDigit(code)) {
+            throw new Error('Invalid cookie domain');
+          }
+
+          if (!isLetterOrDigit(code) && code !== 0x2d) {
+            // "-"
+            throw new Error('Invalid cookie domain');
+          }
+
+          if (++labelLength > 63) {
+            throw new Error('Invalid cookie domain');
+          }
+        }
+
         if (
-          domain.startsWith('-') ||
-          domain.endsWith('.') ||
-          domain.endsWith('-')
+          labelLength === 0 ||
+          domain.charCodeAt(domain.length - 1) === 0x2d
         ) {
+          // "-"
           throw new Error('Invalid cookie domain');
         }
       }
@@ -22147,7 +22421,13 @@ ${pendingInterceptorsFormatter.format(pending)}
 
           const [key, ...value] = part.split('=');
 
-          out.push(`${key.trim()}=${value.join('=')}`);
+          const trimmedKey = key.trim();
+          const joinedValue = value.join('=');
+
+          validateCookieName(trimmedKey);
+          validateCookieValue(joinedValue);
+
+          out.push(`${trimmedKey}=${joinedValue}`);
         }
 
         return out.join('; ');
@@ -35384,44 +35664,39 @@ ${pendingInterceptorsFormatter.format(pending)}
       const kBuffer = Symbol('kBuffer');
       const kLength = Symbol('kLength');
 
-      // Default maximum decompressed message size: 4 MB
-      const kDefaultMaxDecompressedSize = 4 * 1024 * 1024;
-
       class PerMessageDeflate {
         /** @type {import('node:zlib').InflateRaw} */
         #inflate;
 
         #options = {};
 
-        /** @type {boolean} */
-        #aborted = false;
-
-        /** @type {Function|null} */
-        #currentCallback = null;
+        #maxPayloadSize = 0;
 
         /**
          * @param {Map<string, string>} extensions
          */
-        constructor(extensions) {
+        constructor(extensions, options) {
           this.#options.serverNoContextTakeover = extensions.has(
             'server_no_context_takeover'
           );
           this.#options.serverMaxWindowBits = extensions.get(
             'server_max_window_bits'
           );
+
+          this.#maxPayloadSize = options.maxPayloadSize;
         }
 
+        /**
+         * Decompress a compressed payload.
+         * @param {Buffer} chunk Compressed data
+         * @param {boolean} fin Final fragment flag
+         * @param {Function} callback Callback function
+         */
         decompress(chunk, fin, callback) {
           // An endpoint uses the following algorithm to decompress a message.
           // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
           //     payload of the message.
           // 2.  Decompress the resulting data using DEFLATE.
-
-          if (this.#aborted) {
-            callback(new MessageSizeExceededError());
-            return;
-          }
-
           if (!this.#inflate) {
             let windowBits = Z_DEFAULT_WINDOWBITS;
 
@@ -35445,23 +35720,15 @@ ${pendingInterceptorsFormatter.format(pending)}
             this.#inflate[kLength] = 0;
 
             this.#inflate.on('data', (data) => {
-              if (this.#aborted) {
-                return;
-              }
-
               this.#inflate[kLength] += data.length;
 
-              if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
-                this.#aborted = true;
+              if (
+                this.#maxPayloadSize > 0 &&
+                this.#inflate[kLength] > this.#maxPayloadSize
+              ) {
+                callback(new MessageSizeExceededError());
                 this.#inflate.removeAllListeners();
-                this.#inflate.destroy();
                 this.#inflate = null;
-
-                if (this.#currentCallback) {
-                  const cb = this.#currentCallback;
-                  this.#currentCallback = null;
-                  cb(new MessageSizeExceededError());
-                }
                 return;
               }
 
@@ -35474,14 +35741,13 @@ ${pendingInterceptorsFormatter.format(pending)}
             });
           }
 
-          this.#currentCallback = callback;
           this.#inflate.write(chunk);
           if (fin) {
             this.#inflate.write(tail);
           }
 
           this.#inflate.flush(() => {
-            if (this.#aborted || !this.#inflate) {
+            if (!this.#inflate) {
               return;
             }
 
@@ -35492,7 +35758,6 @@ ${pendingInterceptorsFormatter.format(pending)}
 
             this.#inflate[kBuffer].length = 0;
             this.#inflate[kLength] = 0;
-            this.#currentCallback = null;
 
             callback(null, full);
           });
@@ -35536,6 +35801,12 @@ ${pendingInterceptorsFormatter.format(pending)}
       const { WebsocketFrameSend } = __nccwpck_require__(3264);
       const { closeWebSocketConnection } = __nccwpck_require__(6897);
       const { PerMessageDeflate } = __nccwpck_require__(9469);
+      const { MessageSizeExceededError } = __nccwpck_require__(8707);
+
+      function failWebsocketConnectionWithCode(ws, code, reason) {
+        closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason));
+        failWebsocketConnection(ws, reason);
+      }
 
       // This code was influenced by ws released under the MIT license.
       // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -35544,6 +35815,7 @@ ${pendingInterceptorsFormatter.format(pending)}
 
       class ByteParser extends Writable {
         #buffers = [];
+        #fragmentsBytes = 0;
         #byteOffset = 0;
         #loop = false;
 
@@ -35555,20 +35827,29 @@ ${pendingInterceptorsFormatter.format(pending)}
         /** @type {Map<string, PerMessageDeflate>} */
         #extensions;
 
+        /** @type {number} */
+        #maxFragments;
+
+        /** @type {number} */
+        #maxPayloadSize;
+
         /**
          * @param {import('./websocket').WebSocket} ws
          * @param {Map<string, string>|null} extensions
+         * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
          */
-        constructor(ws, extensions) {
+        constructor(ws, extensions, options = {}) {
           super();
 
           this.ws = ws;
           this.#extensions = extensions == null ? new Map() : extensions;
+          this.#maxFragments = options.maxFragments ?? 0;
+          this.#maxPayloadSize = options.maxPayloadSize ?? 0;
 
           if (this.#extensions.has('permessage-deflate')) {
             this.#extensions.set(
               'permessage-deflate',
-              new PerMessageDeflate(extensions)
+              new PerMessageDeflate(extensions, options)
             );
           }
         }
@@ -35583,6 +35864,24 @@ ${pendingInterceptorsFormatter.format(pending)}
           this.#loop = true;
 
           this.run(callback);
+        }
+
+        #validatePayloadLength() {
+          if (
+            this.#maxPayloadSize > 0 &&
+            !isControlFrame(this.#info.opcode) &&
+            this.#info.payloadLength + this.#fragmentsBytes >
+              this.#maxPayloadSize
+          ) {
+            failWebsocketConnectionWithCode(
+              this.ws,
+              1009,
+              'Payload size exceeds maximum allowed size'
+            );
+            return false;
+          }
+
+          return true;
         }
 
         /**
@@ -35695,6 +35994,10 @@ ${pendingInterceptorsFormatter.format(pending)}
               if (payloadLength <= 125) {
                 this.#info.payloadLength = payloadLength;
                 this.#state = parserStates.READ_DATA;
+
+                if (!this.#validatePayloadLength()) {
+                  return;
+                }
               } else if (payloadLength === 126) {
                 this.#state = parserStates.PAYLOADLENGTH_16;
               } else if (payloadLength === 127) {
@@ -35719,6 +36022,10 @@ ${pendingInterceptorsFormatter.format(pending)}
 
               this.#info.payloadLength = buffer.readUInt16BE(0);
               this.#state = parserStates.READ_DATA;
+
+              if (!this.#validatePayloadLength()) {
+                return;
+              }
             } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
               if (this.#byteOffset < 8) {
                 return callback();
@@ -35744,6 +36051,10 @@ ${pendingInterceptorsFormatter.format(pending)}
 
               this.#info.payloadLength = lower;
               this.#state = parserStates.READ_DATA;
+
+              if (!this.#validatePayloadLength()) {
+                return;
+              }
             } else if (this.#state === parserStates.READ_DATA) {
               if (this.#byteOffset < this.#info.payloadLength) {
                 return callback();
@@ -35756,20 +36067,32 @@ ${pendingInterceptorsFormatter.format(pending)}
                 this.#state = parserStates.INFO;
               } else {
                 if (!this.#info.compressed) {
-                  this.#fragments.push(body);
+                  if (!this.writeFragments(body)) {
+                    return;
+                  }
+
+                  if (
+                    this.#maxPayloadSize > 0 &&
+                    this.#fragmentsBytes > this.#maxPayloadSize
+                  ) {
+                    failWebsocketConnectionWithCode(
+                      this.ws,
+                      1009,
+                      new MessageSizeExceededError().message
+                    );
+                    return;
+                  }
 
                   // If the frame is not fragmented, a message has been received.
                   // If the frame is fragmented, it will terminate with a fin bit set
                   // and an opcode of 0 (continuation), therefore we handle that when
                   // parsing continuation frames, not here.
                   if (!this.#info.fragmented && this.#info.fin) {
-                    const fullMessage = Buffer.concat(this.#fragments);
                     websocketMessageReceived(
                       this.ws,
                       this.#info.binaryType,
-                      fullMessage
+                      this.consumeFragments()
                     );
-                    this.#fragments.length = 0;
                   }
 
                   this.#state = parserStates.INFO;
@@ -35778,11 +36101,33 @@ ${pendingInterceptorsFormatter.format(pending)}
                     .get('permessage-deflate')
                     .decompress(body, this.#info.fin, (error, data) => {
                       if (error) {
-                        failWebsocketConnection(this.ws, error.message);
+                        const code =
+                          error instanceof MessageSizeExceededError
+                            ? 1009
+                            : 1007;
+                        failWebsocketConnectionWithCode(
+                          this.ws,
+                          code,
+                          error.message
+                        );
                         return;
                       }
 
-                      this.#fragments.push(data);
+                      if (!this.writeFragments(data)) {
+                        return;
+                      }
+
+                      if (
+                        this.#maxPayloadSize > 0 &&
+                        this.#fragmentsBytes > this.#maxPayloadSize
+                      ) {
+                        failWebsocketConnectionWithCode(
+                          this.ws,
+                          1009,
+                          new MessageSizeExceededError().message
+                        );
+                        return;
+                      }
 
                       if (!this.#info.fin) {
                         this.#state = parserStates.INFO;
@@ -35794,12 +36139,11 @@ ${pendingInterceptorsFormatter.format(pending)}
                       websocketMessageReceived(
                         this.ws,
                         this.#info.binaryType,
-                        Buffer.concat(this.#fragments)
+                        this.consumeFragments()
                       );
 
                       this.#loop = true;
                       this.#state = parserStates.INFO;
-                      this.#fragments.length = 0;
                       this.run(callback);
                     });
 
@@ -35851,6 +36195,39 @@ ${pendingInterceptorsFormatter.format(pending)}
           this.#byteOffset -= n;
 
           return buffer;
+        }
+
+        writeFragments(fragment) {
+          if (
+            this.#maxFragments > 0 &&
+            this.#fragments.length === this.#maxFragments
+          ) {
+            failWebsocketConnectionWithCode(
+              this.ws,
+              1008,
+              'Too many message fragments'
+            );
+            return false;
+          }
+
+          this.#fragmentsBytes += fragment.length;
+          this.#fragments.push(fragment);
+          return true;
+        }
+
+        consumeFragments() {
+          const fragments = this.#fragments;
+
+          if (fragments.length === 1) {
+            this.#fragmentsBytes = 0;
+            return fragments.shift();
+          }
+
+          const output = Buffer.concat(fragments, this.#fragmentsBytes);
+          this.#fragments = [];
+          this.#fragmentsBytes = 0;
+
+          return output;
         }
 
         parseCloseBody(data) {
@@ -36967,7 +37344,15 @@ ${pendingInterceptorsFormatter.format(pending)}
           // once this happens, the connection is open
           this[kResponse] = response;
 
-          const parser = new ByteParser(this, parsedExtensions);
+          const webSocketOptions =
+            this[kController]?.dispatcher?.webSocketOptions;
+          const maxFragments = webSocketOptions?.maxFragments;
+          const maxPayloadSize = webSocketOptions?.maxPayloadSize;
+
+          const parser = new ByteParser(this, parsedExtensions, {
+            maxFragments,
+            maxPayloadSize,
+          });
           parser.on('drain', onParserDrain);
           parser.on('error', onParserError.bind(this));
 
@@ -42072,7 +42457,7 @@ ${pendingInterceptorsFormatter.format(pending)}
     // pkg/dist-src/defaults.js
 
     // pkg/dist-src/version.js
-    var dist_bundle_VERSION = '10.0.11';
+    var dist_bundle_VERSION = '10.0.13';
 
     // pkg/dist-src/defaults.js
     var defaults_default = {
@@ -42225,8 +42610,11 @@ ${pendingInterceptorsFormatter.format(pending)}
           return text;
         }
       } else if (
-        mimetype.type.startsWith('text/') ||
-        mimetype.parameters.charset?.toLowerCase() === 'utf-8'
+        mimetype.type.startsWith('text/') || // `application/octet-stream` is the canonical "arbitrary binary" type
+        // (RFC 2046) and must never be decoded as text, even when the response
+        // carries a (misleading) `charset=utf-8` parameter — see #751.
+        (mimetype.parameters.charset?.toLowerCase() === 'utf-8' &&
+          mimetype.type !== 'application/octet-stream')
       ) {
         return response.text().catch(noop);
       } else {
@@ -45227,7 +45615,7 @@ ${pendingInterceptorsFormatter.format(pending)}
         rest: api,
       };
     }
-    legacyRestEndpointMethods.VERSION = dist_src_version_VERSION; // CONCATENATED MODULE: ./node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
+    legacyRestEndpointMethods.VERSION = dist_src_version_VERSION; // CONCATENATED MODULE: ./node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
 
     //# sourceMappingURL=index.js.map
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "devDependencies": {
         "@stylistic/eslint-plugin": "^2.6.1",
         "@kesills/eslint-config-airbnb-typescript": "20.0.0",
-        "@octokit/plugin-paginate-rest": "14.0.0",
-        "@octokit/request": "10.0.11",
+        "@octokit/plugin-paginate-rest": "15.0.0",
+        "@octokit/request": "10.0.13",
         "@octokit/request-error": "7.1.1",
         "@types/node": "^26.1.2",
         "@typescript-eslint/eslint-plugin": "8.65.0",
@@ -47,11 +47,11 @@
         "vitest": "^4.1.10"
     },
     "resolutions": {
-        "@octokit/request": "10.0.11",
+        "@octokit/request": "10.0.13",
         "esbuild": "0.28.1",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "glob": "11.1.0",
-        "undici": "6.24.1",
+        "undici": "6.28.0",
         "picomatch": "4.0.4",
         "eslint/minimatch/brace-expansion": "1.1.16",
         "eslint-plugin-import/minimatch/brace-expansion": "1.1.16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "target": "es6",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "ignoreDeprecations": "6.0",
     "lib": ["esnext", "dom"],
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,7 +313,14 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz#a8e47691c1602f47764e7f15d165d6f66736b005"
   integrity sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==
 
-"@octokit/plugin-paginate-rest@14.0.0", "@octokit/plugin-paginate-rest@^14.0.0":
+"@octokit/plugin-paginate-rest@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-15.0.0.tgz#17b0dae6f33459888f790b40c5aaf087803d63a8"
+  integrity sha512-lw9A9YL5s4VPj+VEx8uMxaxQm2YTgrPDkrLEuZuu18R8TK3oPcXF4K6t52nx6xn1RcogZC9i188sAr/4XYJaQQ==
+  dependencies:
+    "@octokit/types" "^17.0.0"
+
+"@octokit/plugin-paginate-rest@^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz#44dc9fff2dacb148d4c5c788b573ddc044503026"
   integrity sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==
@@ -327,21 +334,21 @@
   dependencies:
     "@octokit/types" "^16.0.0"
 
-"@octokit/request-error@7.1.1", "@octokit/request-error@^7.0.2", "@octokit/request-error@^7.1.0":
+"@octokit/request-error@7.1.1", "@octokit/request-error@^7.0.2", "@octokit/request-error@^7.1.0", "@octokit/request-error@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-7.1.1.tgz#cd928d96355742853905be847bb7ab6ec6a7d518"
   integrity sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==
   dependencies:
     "@octokit/types" "^17.0.0"
 
-"@octokit/request@10.0.11", "@octokit/request@^10.0.6", "@octokit/request@^10.0.7":
-  version "10.0.11"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-10.0.11.tgz#a11d8b9bae5f6e868efb7dea946edd855ebb2549"
-  integrity sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==
+"@octokit/request@10.0.13", "@octokit/request@^10.0.6", "@octokit/request@^10.0.7":
+  version "10.0.13"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-10.0.13.tgz#471bd23246bb71d9bc954201999a6f6c8da01ca9"
+  integrity sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==
   dependencies:
     "@octokit/endpoint" "^11.0.3"
-    "@octokit/request-error" "^7.0.2"
-    "@octokit/types" "^16.0.0"
+    "@octokit/request-error" "^7.1.1"
+    "@octokit/types" "^17.0.0"
     content-type "^2.0.0"
     json-with-bigint "^3.5.3"
     universal-user-agent "^7.0.2"
@@ -1991,10 +1998,10 @@ jackspeak@^4.1.1:
   dependencies:
     "@isaacs/cliui" "^9.0.0"
 
-js-yaml@4.3.0, js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@4.3.1, js-yaml@^4.1.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -2949,10 +2956,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@6.24.1, undici@^6.23.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
-  integrity sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==
+undici@6.28.0, undici@^6.23.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
   version "7.0.3"


### PR DESCRIPTION
Upgraded direct dependencies (@octokit/plugin-paginate-rest to 15.0.0, @octokit/request to 10.0.13) and patched security vulnerabilities in transitive dependencies (js-yaml to 4.3.1, undici to 6.28.0) in package.json and yarn.lock. Updated moduleResolution in tsconfig.json to 'bundler' to support modern package exports, verified all tests and linter pass, and rebuilt dist/index.js.

---
*PR created automatically by Jules for task [14972778160685040916](https://jules.google.com/task/14972778160685040916) started by @slord399*