### PR TITLE
Build(deps-dev): bump @vercel/ncc from 0.44.1 to 0.45.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37936,6 +37936,10 @@ ${pendingInterceptorsFormatter.format(pending)}
   }
   /******/
   /************************************************************************/
+  /******/ /* webpack/runtime/asset-relocator-loader */
+  /******/ if (typeof __nccwpck_require__ !== 'undefined')
+    __nccwpck_require__.ab = __dirname + '/';
+  /******/
   /******/ /* webpack/runtime/compat get default export */
   /******/ (() => {
     /******/ // getDefaultExport function for compatibility with non-harmony modules
@@ -37990,11 +37994,6 @@ ${pendingInterceptorsFormatter.format(pending)}
     };
     /******/
   })();
-  /******/
-  /******/ /* webpack/runtime/compat */
-  /******/
-  /******/ if (typeof __nccwpck_require__ !== 'undefined')
-    __nccwpck_require__.ab = __dirname + '/';
   /******/
   /************************************************************************/
   var __webpack_exports__ = {};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@types/node": "^26.1.2",
         "@typescript-eslint/eslint-plugin": "8.65.0",
         "@typescript-eslint/parser": "8.67.0",
-        "@vercel/ncc": "0.44.1",
+        "@vercel/ncc": "0.45.0",
         "braces": "3.0.3",
         "esbuild": "0.28.2",
         "eslint": "8.57.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,10 +784,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.2.tgz#a03ad82cd5676414d068ba86f880c5681194aadf"
   integrity sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==
 
-"@vercel/ncc@0.44.1":
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.44.1.tgz#5becc6500a1494e5b9786150da6374d0b2d7671d"
-  integrity sha512-cUjIE5P2YY1n+Kt9rFIazMMpGoPn1Fic04rOmTkElMkiDP5oszGfERMpo2shVkFKDL7rVppdM2pqJKC59shQWQ==
+"@vercel/ncc@0.45.0":
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.45.0.tgz#e1e2424d9eb0dbb3a8fa7067e36e0da96d42a316"
+  integrity sha512-8zPi1yO2mHpoKTD+e+Bf0ZT3e+sWHSOyGapm9s7b5R0gxJi3CiFTqmeQiMEyu6ejrz2s09M8JkEoUaTWjBJPQQ==
 
 "@vitest/expect@4.1.10":
   version "4.1.10"


### PR DESCRIPTION
Bumped @vercel/ncc from 0.44.1 to 0.45.0 in package.json, updated yarn.lock, and rebuilt the dist artifacts. All tests and lint checks pass.

---
*PR created automatically by Jules for task [1733694092940461359](https://jules.google.com/task/1733694092940461359) started by @slord399*